### PR TITLE
Removing Basic Auth reference

### DIFF
--- a/source/API_Reference/Web_API_v3/How_To_Use_The_Web_API_v3/authentication.md
+++ b/source/API_Reference/Web_API_v3/How_To_Use_The_Web_API_v3/authentication.md
@@ -41,7 +41,7 @@ The on-behalf-of header allows you to make calls for a particular subuser throug
 
 This will generate the api call as if it was the subuser account itself making the call. Just make sure you are using the correct subuser username.
 
-When authenticating using the on-behalf-of header, you will need to use the API key or basic auth credentials of the parent account.
+When authenticating using the on-behalf-of header, you will need to use the API key credentials of the parent account.
  
 {% anchor h3 %}
 Using API Key:


### PR DESCRIPTION
<!-- 
Removing Basic Auth reference
-->

**Description of the change**: Removing Basic Auth reference
**Reason for the change**: Basic Auth is still referenced in the documentation
**Link to original source**:
<!-- 
If this pull request closes an issue, add in the issue number here 
-->
Closes #3122

@ksigler7
